### PR TITLE
Provide Redux support

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,8 @@
   "parser": "babel-eslint",
 
   "plugins": [
-    "babel"
+    "babel",
+    "react"
   ],
 
   "env": {
@@ -209,6 +210,8 @@
     "vars-on-top": 0,
     "wrap-iife": 2,
     "wrap-regex": 0,
-    "yoda": [2, "never", {"exceptRange": true}]
+    "yoda": [2, "never", {"exceptRange": true}],
+    "react/jsx-uses-react": 1,
+    "react/jsx-uses-vars": 1
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "mocha": "2.x.x",
     "chai": "3.x.x",
     "eslint": "1.7.x",
+    "eslint-plugin-react": "3.15.x",
     "babel-eslint": "4.x.x",
     "eslint-plugin-babel": "2.x.x",
     "babel-cli": "6.x.x",
@@ -36,6 +37,8 @@
   "dependencies": {
     "babel-runtime": "6.x.x",
     "react-komposer": "^1.8.0",
-    "react-simple-di": "^1.2.0"
+    "react-redux": "^4.4.5",
+    "react-simple-di": "^1.2.0",
+    "redux": "^3.5.1"
   }
 }

--- a/src/__tests__/app.js
+++ b/src/__tests__/app.js
@@ -56,6 +56,30 @@ describe('App', () => {
       });
     });
 
+    describe('has reducers field', () => {
+      it('should fail if reducers is not an object whose values are ' +
+        'reducer functions', () => {
+        const app = new App({});
+        const module = {
+          reducers() {}
+        };
+        const errorMatch = /Module's reducers field should/;
+        expect(app.loadModule.bind(app, module)).to.throw(errorMatch);
+      });
+
+      it('should save reducers', () => {
+        const app = new App({});
+        const module = {
+          reducers: {
+            foo() {}
+          }
+        };
+
+        app.loadModule(module);
+        expect(app._reducers).to.be.deep.equal(module.reducers);
+      });
+    });
+
     it('should merge actions with app wide global actions', () => {
       const app = new App({});
       app.actions = {bb: 10};
@@ -136,6 +160,19 @@ describe('App', () => {
       expect(calledRoutes).to.deep.equal([ 1, 2 ]);
     });
 
+    it('should create the Redux store from saved reducers', () => {
+      const app = new App({});
+      app._reducers = {
+        foo(state = {}) {
+          return state;
+        }
+      };
+
+      app.init();
+      expect(app.context.ReduxStore.getState()).to.deep.equal({
+        foo: {}
+      });
+    });
 
     it('should mark as initialized', () => {
       const app = new App({});

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,9 @@ import {
 } from 'react-komposer';
 
 import App from './app';
+import {
+  default as _withRedux
+} from './redux_container';
 
 // export this module's functions
 export const createApp = (...args) => (new App(...args));
@@ -26,3 +29,6 @@ export const composeWithPromise = _composeWithPromise;
 export const composeWithObservable = _composeWithObservable;
 export const composeAll = _composeAll;
 export const disable = _disable;
+
+// export
+export const withRedux = _withRedux;

--- a/src/redux_container.js
+++ b/src/redux_container.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Provider, connect } from 'react-redux';
+import { useDeps } from 'react-simple-di';
+import { composeAll } from 'react-komposer';
+
+const withRedux = (mapStateToProps, mapDispatchToProps, mergeProps,
+  options) => {
+  const provider = Component => {
+    return props => {
+      const {context, children, ...nextProps} = props;
+      const component = React.createElement(Component, nextProps, children);
+      return React.createElement(Provider,
+        {store: context().ReduxStore}, component);
+    };
+  };
+
+  return composeAll(
+    connect(mapStateToProps, mapDispatchToProps, mergeProps, options),
+    provider,
+    useDeps()
+  );
+};
+
+export default withRedux;


### PR DESCRIPTION
As a practical architecture of Meteor projects, it would be great if mantra provides a standard way of integrating Redux into mantra projects. The mantra guide does mention that we can manage applications' local states via Redux [[ref](https://kadirahq.github.io/mantra/#sec-State-Management)]. Unfortunately, up till now, there are no "official" and easy ways of doing so in mantra.

Therefore, I have extended the `mantra-core` package to include Redux support.

First of all, a module might contain the definition of an map of reducer functions:

``` javascript
// definition of a module

const reducers = {
  foo: function(state, action) { return state; }
};

export default {
  actions,
  routes,
  reducers,
  load() {
  }
};
```

 When the `App` instance "loads" the module by `loadModule`, as well as dealing with routes and actions, it also collects the module's reducers and adds them to `app._reducers`.

After all modules have been loaded, in `init()`, the `App` tries to combine the reducers, and from which a Redux store is created afterwards. The store will be added to the context, named `ReduxStore`.

For Redux containers to access the store, I use `Provider` and `connect` from the `react-redux` package to bind React, Redux and mantra together. All these behaviours are implemented in the `withRedux` function.

Imagine we want to build a Redux container, which maps the app's state to props and provide them to its children presentation components. We can do it easily with just one line of code:

``` javascript
import { withRedux } from 'mantra-core';

// defines mapStateToProps

const ReduxContainer = withRedux(mapStateToProps)(ChildComponent);
```

Then we can happily use the container:

``` javascript
render() {
  return (
    <ReduxContainer {...props} />
  );
}
```

I've forked `mantra-sample-blog-app` and added a Redux counter component to it, which may serve as a demo of the integration of Redux into mantra projects:

https://github.com/haizi-zh/mantra-sample-blog-app/tree/new-mantra-core/client/modules/redux_demo
